### PR TITLE
Update gatsby config to load plugins in the right order

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,6 +5,8 @@ module.exports = {
       'This repo is the main webpage for Pi515. It is built with Gatsby, and Netlify CMS.It follows the JAMstack architecture by using Git as a single source of truth, and Netlify for continuous deployment, and CDN distribution.',
   },
   plugins: [
+    'gatsby-plugin-sharp',
+    'gatsby-transformer-sharp',
     'gatsby-plugin-react-helmet',
     'gatsby-plugin-sass',
     {
@@ -34,8 +36,6 @@ module.exports = {
         name: 'images',
       },
     },
-    'gatsby-plugin-sharp',
-    'gatsby-transformer-sharp',
     {
       resolve: 'gatsby-transformer-remark',
       options: {


### PR DESCRIPTION
**Issue being addressed:**
Local builds are busted

**How does this PR address it?**
Puts the image imports in the right order

**What needs to be documented once your changes are merged?**
Just read the docs